### PR TITLE
Fix issue with spaces in filenames

### DIFF
--- a/rofigen
+++ b/rofigen
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $1
+"source $1"
 
 # Window title
 ROFI_TEXT=$title

--- a/rofigen
+++ b/rofigen
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-"source $1"
+source "$1"
 
 # Window title
 ROFI_TEXT=$title


### PR DESCRIPTION
Related to issue #4 

If the path of the script I am passing to rofigen.sh has a space in it, the script breaks even if I use a backslash or double/single quotes to escape it.

The issue appears to be line 3 of rofigen: source $1

I replaced it with source "$1" and that fixed the issue for me,